### PR TITLE
use absolute link to ergo.css via config.base_url

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
         <meta name="viewport"  content="width=device-width, initial-scale=1.0, maximum-scale=1" >
 
         <!--  css -->
-        <link rel="stylesheet"  href="/ergo.css" >
+        <link rel="stylesheet"  href="{{ config.base_url }}/ergo.css" >
 
         <!-- fonts -->
         <!-- preload  -->


### PR DESCRIPTION
If this is not done, it causes problem with url website like *domain.com/~username*.
The css file url is *domain.com/ergo.css* instead of *domain.com/~username/ergo.css*