### PR TITLE
Wrap header description in safe

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
       <a href="{{config.base_url}}" style="background-image: url({{config.base_url}}/img/{{config.extra.profile}}"></a>
   </figure>
   <h2 class="site_title">{{config.title}}</h2>
-  <div>{{config.description | markdown(inline=true)}}</div>
+  <div>{{config.description | markdown(inline=true) | safe }}</div>
   {{ macros::social_list(classes="header_list", bsize="small", extra=config.extra, siteurl=config.base_url, rss=config.generate_rss) }}
   {% endblock header %}
 </header>


### PR DESCRIPTION
This enables the proper rendering of the quotation marks and `*italic* - quote` in the description.