### PR TITLE
Customize title according to 'page.title'

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,11 @@
         <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
         <!-- SEO -->
+        {% if page.title %}
+        <title> {{ page.title }} | {{ config.title }} </title>
+        {% else %}
         <title> {{ config.title }} </title>
+        {% endif %}
 
         <!-- Enable responsiveness on mobile devices-->
         <meta name="viewport"  content="width=device-width, initial-scale=1.0, maximum-scale=1" >


### PR DESCRIPTION
### Changed

* Customize page title according to `page.title`, if it exists.

If `page.title` exists, the title of the page is set to `{{ page.title }} | {{ config.title }}`. Otherwise, it falls back to the value of `{{ config.title }}` alone. This works great for blog posts, where the page title now actually contains the name of the article.