### PR TITLE
Use generate_feed following Zola v0.11.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ description="\"*to develop the skill of correct thinking is in the first place t
 default_language = "en"
 
 highlight_theme = "solarized-light"
-generate_rss = true
+generate_feed = true
 rss_limit = 20
 
 # Whether to automatically compile all Sass files in the sass directory

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
 
     <body>
       {% block menu %}
-        {{ macros::menu(title=config.title, siteurl=config.base_url, extra=config.extra, rss=config.generate_rss) }}
+        {{ macros::menu(title=config.title, siteurl=config.base_url, extra=config.extra, rss=config.generate_feed) }}
       {% endblock menu %}
 
       {% block content %} {% endblock content %}
@@ -40,7 +40,7 @@
       <footer>
         {% block footer %}
           {{ macros::mini_logo(classes="", title=config.title, siteurl=config.base_url, logourl=config.extra.profile) }}
-          {{ macros::social_list(classes="foot_list", bsize="extra_small", extra=config.extra, siteurl=config.base_url, rss=config.generate_rss) }}
+          {{ macros::social_list(classes="foot_list", bsize="extra_small", extra=config.extra, siteurl=config.base_url, rss=config.generate_feed) }}
         {% endblock footer %}
       </footer>
     </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
   </figure>
   <h2 class="site_title">{{config.title}}</h2>
   <div>{{config.description | markdown(inline=true) | safe }}</div>
-  {{ macros::social_list(classes="header_list", bsize="small", extra=config.extra, siteurl=config.base_url, rss=config.generate_rss) }}
+  {{ macros::social_list(classes="header_list", bsize="small", extra=config.extra, siteurl=config.base_url, rss=config.generate_feed) }}
   {% endblock header %}
 </header>
 


### PR DESCRIPTION
Since Zola v0.11.0, config variable generate_rss has changed for generate_feed.
This pull request fix Ergo accordingly to this change.