### PR TITLE
Update README with paginate_by dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Here's a timelapse:
 Get [Zola](https://www.getzola.org/) and/or follow their guide on [installing a theme](https://www.getzola.org/documentation/themes/installing-and-using-themes/).
 Make sure to add `theme = "ergo"` to your `config.toml`
 
+Ergo relies on having `paginate_by` variable set in `content/_index.md`.
+
 #### Check zola version (only 0.11.0+)
 Just to double-check to make sure you have the right version. It is not supported to use this theme with a version under 0.11.0.
 


### PR DESCRIPTION
Thank you for the theme!

TLDR:
ergo relies on paginate_by being set in `content/_index.md` and I updated the readme to guide new installations.

This puzzled me for a few minutes because of the error messages not pointing specifically to the issue 😬 .

I found the resolution by experimenting with other themes and seeing a note about this in after-dark theme's readme.