### PR TITLE
Bugfix/0.14 upgrades

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -41,7 +41,7 @@
 
       <footer>
         {% block footer %}
-          {{ macros::mini_logo(classes="", title=config.title, siteurl=config.base_url, logourl=config.extra.profile) }}
+          {{ macros::mini_logo(classes="", title=config.title, siteurl=base_url, logourl=config.extra.profile) }}
           {{ macros::social_list(classes="foot_list", bsize="extra_small") }}
           {{ macros::theme_selector(themes=config.extra.color_themes) }}
         {% endblock footer %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,8 +5,9 @@
 <nav>{% include "languages.html" %}</nav>
 <header class="header">
   {% block header %}
+  {% set base_url = get_url(path="/", lang=lang) %}
   <figure class="user_logo">
-      <a href="{{config.base_url}}" style="background-image: url({{config.base_url}}/img/{{config.extra.profile}}"></a>
+      <a href="{{ base_url }}" style="background-image: url({{config.base_url}}/img/{{config.extra.profile}}"></a>
   </figure>
   <h2 class="site_title">{{config.title}}</h2>
   <div>{{ config.description | as_str | markdown(inline=true) | safe }}</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
       <a href="{{config.base_url}}" style="background-image: url({{config.base_url}}/img/{{config.extra.profile}}"></a>
   </figure>
   <h2 class="site_title">{{config.title}}</h2>
-  <div>{{config.description | markdown(inline=true) | safe }}</div>
+  <div>{{ config.description | as_str | markdown(inline=true) | safe }}</div>
   {{ macros::social_list(classes="header_list", bsize="small") }}
   {% endblock header %}
 </header>

--- a/templates/languages.html
+++ b/templates/languages.html
@@ -1,29 +1,23 @@
 {% import "macros.html" as macros %}
 
 {% block language_selector %}
-{% set languages = config.languages | map(attribute="code") %}
-{% set default_language = config.default_language %}
-{% if languages | length %}
+{% if config.languages | length %}
 <div id="languageSelector">
     <ul>
         {% set defpath = current_path %}
-        {% if lang != default_language %}
-        {% set defpath = defpath | trim_start_matches(pat="/" ~ lang) %}
+        {% if current_path is starting_with("/" ~ lang) %}
+            {% set defpath = defpath | trim_start_matches(pat="/" ~ lang) %}
         {% endif %}
 
-        {% for l in languages | concat(with=default_language) | sort %}
+        {% for l, value in config.languages %}
         <li>
-            {% if l != lang %}
             <a href="{{get_url(path=defpath, lang=l)}}">
-            {% endif %}
             {% if config.extra.country_flags %}
                 {{ macros::country_flag(language=l) }}
             {% else %}
                 {{ l }}
             {% endif %}
-            {% if l != lang %}
             </a>
-            {% endif %}
         </li>
         {% endfor %}
 

--- a/templates/languages.html
+++ b/templates/languages.html
@@ -4,10 +4,7 @@
 {% if config.languages | length %}
 <div id="languageSelector">
     <ul>
-        {% set defpath = current_path %}
-        {% if current_path is starting_with("/" ~ lang) %}
-            {% set defpath = defpath | trim_start_matches(pat="/" ~ lang) %}
-        {% endif %}
+        {% set defpath = current_path | trim_start_matches(pat="/" ~ lang ~ "/") %}
 
         {% for l, value in config.languages %}
         <li>

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,7 +3,8 @@
 
 {% block content %}
 <nav id="overlord" class="overlord" >
-  {{ macros::mini_logo(classes="", title=config.title, siteurl=config.base_url, logourl=config.extra.profile) }}
+  {% set base_url = get_url(path="/", lang=lang) %}
+  {{ macros::mini_logo(classes="", title=config.title, siteurl=base_url, logourl=config.extra.profile) }}
   {% include "languages.html" %}
 </nav>
 


### PR DESCRIPTION
Fixes: #44

Also fixes a couple of previously non-language aware links, e.g. those linking to `config.base_url`

Add a config section like 

```

[languages]
[languages.fr]
title = "Mon blog"
generate_feed = true
taxonomies = [
   {name = "auteurs"},
   {name = "tags"},
]

[languages.de]
title = "Mei blog"
generate_feed = true
taxonomies = []
```

and create the required files in that language, e.g. `_index.fr.md` to test it out.