### PR TITLE
More 0.14 language fixes.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -41,6 +41,7 @@
 
       <footer>
         {% block footer %}
+          {% set base_url = get_url(path="/", lang=lang) %}
           {{ macros::mini_logo(classes="", title=config.title, siteurl=base_url, logourl=config.extra.profile) }}
           {{ macros::social_list(classes="foot_list", bsize="extra_small") }}
           {{ macros::theme_selector(themes=config.extra.color_themes) }}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -9,7 +9,7 @@
 
 {% macro mini_logo(classes, title, siteurl, logourl) %}
 <figure class="mini_logo {{ classes }}">
-    <a href="{{siteurl}}" style="background-image: url({{siteurl}}/img/{{logourl}})"></a>
+    <a href="{{siteurl}}" style="background-image: url(/img/{{logourl}})"></a>
 </figure>
 <h5>
     <a href="{{siteurl}}">{{title}}</a>


### PR DESCRIPTION
Previous error:
>  Reason: Variable base_url not found in context while rendering 'tags/list.html'

Fixes: #49 
Fixes: #47

Also fixes the logo image when in a translated page.